### PR TITLE
QP dependency v1.0.0

### DIFF
--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -17,7 +17,7 @@ RCT_EXPORT_METHOD(isSensorAvailable: (RCTResponseSenderBlock)callback)
     LAContext *context = [[LAContext alloc] init];
     NSError *error;
 
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         callback(@[[NSNull null], @true]);
     } else {
         // Device does not support FingerprintScanner
@@ -39,9 +39,9 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     }
 
     // Device has FingerprintScanner
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&error]) {
         // Attempt Authentication
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        [context evaluatePolicy:LAPolicyDeviceOwnerAuthentication
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {

--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -18,7 +18,7 @@ RCT_EXPORT_METHOD(isSensorAvailable: (RCTResponseSenderBlock)callback)
     NSError *error;
 
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
-        callback(@[[NSNull null]]);
+        callback(@[[NSNull null], @true]);
     } else {
         // Device does not support FingerprintScanner
         [self handleError:error callback:callback];

--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -48,7 +48,7 @@ RCT_EXPORT_METHOD(sensorType: (RCTResponseSenderBlock)callback)
             biometryType = @"TouchID";
         }
         callback(@[[NSNull null], biometryType]);
-    } else if (error.code == LAErrorTouchIDNotEnrolled){
+    } else if (error.code != LAErrorTouchIDNotAvailable){
         if([[UIDevice currentDevice]userInterfaceIdiom]==UIUserInterfaceIdiomPhone) {
             switch ((int)[[UIScreen mainScreen] nativeBounds].size.height) {
                 case 2436:

--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -18,7 +18,23 @@ RCT_EXPORT_METHOD(isSensorAvailable: (RCTResponseSenderBlock)callback)
     NSError *error;
 
     if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
-        callback(@[[NSNull null], @true]);
+        NSString *biometryType;
+        if (@available(iOS 11.0, *)) {
+            switch (context.biometryType) {
+                case LABiometryTypeFaceID:
+                    biometryType = @"FaceID";
+                    break;
+                case LABiometryTypeTouchID:
+                    biometryType = @"TouchID";
+                    break;
+                default:
+                    biometryType = @"None";
+                    break;
+            }
+        } else {
+            biometryType = @"TouchID";
+        }
+        callback(@[[NSNull null], biometryType]);
     } else {
         // Device does not support FingerprintScanner
         [self handleError:error callback:callback];

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import authenticate from './authenticate';
 import isSensorAvailable from './isSensorAvailable';
 import release from './release';
+import sensorType from './sensorType'
 
 export default {
   authenticate,
   release,
   isSensorAvailable,
+  sensorType,
 };

--- a/src/isSensorAvailable.ios.js
+++ b/src/isSensorAvailable.ios.js
@@ -5,9 +5,9 @@ const { ReactNativeFingerprintScanner } = NativeModules;
 
 export default () => {
   return new Promise((resolve, reject) => {
-    ReactNativeFingerprintScanner.isSensorAvailable(error => {
+    ReactNativeFingerprintScanner.isSensorAvailable((error, sensorType) => {
       if (error) return reject(createError(error.message));
-      resolve(true);
+      resolve(sensorType);
     });
   });
 }

--- a/src/sensorType.js
+++ b/src/sensorType.js
@@ -5,9 +5,9 @@ const { ReactNativeFingerprintScanner } = NativeModules;
 
 export default () => {
   return new Promise((resolve, reject) => {
-    ReactNativeFingerprintScanner.isSensorAvailable((error) => {
+    ReactNativeFingerprintScanner.sensorType((error, sensorType) => {
       if (error) return reject(createError(error.message));
-      resolve();
+      resolve(sensorType);
     });
   });
 }


### PR DESCRIPTION
+ Update evaluation policy - While evaluating sensor availability we check `LAPolicyDeviceOwnerAuthenticationWithBiometrics` but while actually authenticating we check `LAPolicyDeviceOwnerAuthentication`. This allows to distinguish sensor unavailable with sensor not setup, while allowing system provided fallback for passcode.
+ Handle errors centrally - All error handling is now routed via `handleError`, so they have proper name, code, etc.
+ Added method __sensorType__(iOS only) which returns type pf sensor available, and throws error only in the case of sensor unavailable (iPhone 5 and below)